### PR TITLE
Added diff editor color customizations (provisional).

### DIFF
--- a/themes/Posterpole-color-theme.json
+++ b/themes/Posterpole-color-theme.json
@@ -108,7 +108,16 @@
         "terminal.ansiBrightBlue": "#8A99A8",
         "terminal.ansiBrightMagenta": "#CCB3C6",
         "terminal.ansiBrightCyan": "#8FA4A2",
-        "terminal.ansiBrightWhite": "#C6C0B9"
+        "terminal.ansiBrightWhite": "#C6C0B9",
+
+        "diffEditor.border": "#2e2d42",
+        "diffEditor.diagonalFill": "#716b8c4d",
+        "diffEditor.insertedLineBackground": "#6bbdc610",
+        "diffEditor.insertedTextBackground": "#6bbdc610",
+        "diffEditor.removedLineBackground": "#b95e8410",
+        "diffEditor.removedTextBackground": "#b95e8410",
+        "diffEditorOverview.insertedForeground": "#6bbdc680",
+        "diffEditorOverview.removedForeground": "#b95e8480",
     },
     "tokenColors": [
         {


### PR DESCRIPTION
hi @ilof2 ! 

I have added a few colours to make the diff editor more readable. They are provisional as they are not derived from the colours that make up the theme, I will do it soon if you think it's right.

Here is a preview:

![image](https://github.com/user-attachments/assets/89b7de35-e2e0-4634-a8bd-e7ac8fc0e4d4)
